### PR TITLE
1차 스프린트 적용

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/lib/common/color.dart
+++ b/lib/common/color.dart
@@ -1,1 +1,3 @@
+import 'package:flutter/material.dart';
 
+const eliverdTappedColor = Colors.lightBlue;

--- a/lib/common/string.dart
+++ b/lib/common/string.dart
@@ -1,2 +1,11 @@
-const title = 'Eliverd';
-const homeTitle = 'Eliverd for store';
+const title = '엘리버드';
+const homeTitle = '상점용 엘리버드';
+
+const idText = '아이디';
+const passwordText = '비밀번호';
+const login = '로그인';
+const notSignUp = '아직 회원이 아니십니까?';
+
+const addProduct = '등록';
+const checkOut = '결제';
+const removeProduct = '폐기';

--- a/lib/ui/pages/home.dart
+++ b/lib/ui/pages/home.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:Eliverd/common/string.dart';
+import 'package:Eliverd/common/color.dart';
 
 class HomePage extends StatefulWidget {
   @override
@@ -8,12 +9,38 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  int _selectedIndex = 0;
+
+  void _onItemTapped(int index) {
+    setState(() {
+      _selectedIndex = index;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(title),
+      body: Center(
+        child: Text('엘리버드')
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+          items: const <BottomNavigationBarItem>[
+            BottomNavigationBarItem(
+              icon: Icon(Icons.add),
+              title: Text(addProduct),
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.payment),
+              title: Text(checkOut),
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.remove),
+              title: Text(removeProduct),
+            ),
+          ],
+          currentIndex: _selectedIndex,
+          selectedItemColor: eliverdTappedColor,
+          onTap: _onItemTapped
       ),
     );
   }

--- a/lib/ui/pages/home.dart
+++ b/lib/ui/pages/home.dart
@@ -20,28 +20,26 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-        child: Text('엘리버드')
-      ),
+      key: Key('HomePage'),
+      body: Center(child: Text(title)),
       bottomNavigationBar: BottomNavigationBar(
-          items: const <BottomNavigationBarItem>[
-            BottomNavigationBarItem(
-              icon: Icon(Icons.add),
-              title: Text(addProduct),
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.payment),
-              title: Text(checkOut),
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.remove),
-              title: Text(removeProduct),
-            ),
-          ],
-          currentIndex: _selectedIndex,
-          selectedItemColor: eliverdTappedColor,
-          onTap: _onItemTapped
-      ),
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.add),
+            title: Text(addProduct),
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.payment),
+            title: Text(checkOut),
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.remove),
+            title: Text(removeProduct),
+          ),
+        ],
+        currentIndex: _selectedIndex,
+        selectedItemColor: eliverdTappedColor,
+        onTap: _onItemTapped),
     );
   }
 }

--- a/lib/ui/pages/login.dart
+++ b/lib/ui/pages/login.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class LoginPage extends StatefulWidget {
+  @override
+  _LoginPageState createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Login'),
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/login.dart
+++ b/lib/ui/pages/login.dart
@@ -17,10 +17,12 @@ class _LoginPageState extends State<LoginPage> {
     final height = MediaQuery.of(context).size.height;
 
     return Scaffold(
+      key: Key('LoginPage'),
       body: ListView(
         padding: EdgeInsets.all(height / 15.0),
         children: <Widget>[
           TextField(
+            key: Key('IdField'),
             obscureText: false,
             controller: idController,
             decoration: InputDecoration(
@@ -32,6 +34,7 @@ class _LoginPageState extends State<LoginPage> {
           ),
           SizedBox(height: height / 80.0),
           TextField(
+            key: Key('PasswordField'),
             obscureText: true,
             controller: passwordController,
             decoration: InputDecoration(
@@ -43,13 +46,13 @@ class _LoginPageState extends State<LoginPage> {
           ),
           SizedBox(height: height / 80.0),
           RaisedButton(
+            key: Key('SignInButton'),
             child: Text(login),
             onPressed: () => {
               // TO-DO: 로그인 BLOC 구현하기
-              Navigator.push(context,
-                MaterialPageRoute(
-                  builder: (context) => HomePage())
-              )},
+              Navigator.push(
+                  context, MaterialPageRoute(builder: (context) => HomePage()))
+            },
             textColor: Colors.white,
             color: Colors.lightBlue,
             shape: RoundedRectangleBorder(
@@ -58,6 +61,7 @@ class _LoginPageState extends State<LoginPage> {
             padding: EdgeInsets.symmetric(vertical: 15.0),
           ),
           FlatButton(
+            key: Key('SignUpButton'),
             child: Text(notSignUp),
             onPressed: () => {
               // TO-DO: 회원가입 BLOC 구현하기

--- a/lib/ui/pages/login.dart
+++ b/lib/ui/pages/login.dart
@@ -1,4 +1,7 @@
+import 'package:Eliverd/common/string.dart';
 import 'package:flutter/material.dart';
+
+import './home.dart';
 
 class LoginPage extends StatefulWidget {
   @override
@@ -6,12 +9,61 @@ class LoginPage extends StatefulWidget {
 }
 
 class _LoginPageState extends State<LoginPage> {
+  final idController = TextEditingController();
+  final passwordController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
+    final height = MediaQuery.of(context).size.height;
+
     return Scaffold(
-      appBar: AppBar(
-        title: Text('Login'),
+      body: ListView(
+        padding: EdgeInsets.all(height / 15.0),
+        children: <Widget>[
+          TextField(
+            obscureText: false,
+            controller: idController,
+            decoration: InputDecoration(
+              border: OutlineInputBorder(
+                borderRadius: new BorderRadius.circular(15.0),
+              ),
+              labelText: idText,
+            ),
+          ),
+          SizedBox(height: height / 80.0),
+          TextField(
+            obscureText: true,
+            controller: passwordController,
+            decoration: InputDecoration(
+              border: OutlineInputBorder(
+                borderRadius: new BorderRadius.circular(15.0),
+              ),
+              labelText: passwordText,
+            ),
+          ),
+          SizedBox(height: height / 80.0),
+          RaisedButton(
+            child: Text(login),
+            onPressed: () => {
+              // TO-DO: 로그인 BLOC 구현하기
+              Navigator.push(context,
+                MaterialPageRoute(
+                  builder: (context) => HomePage())
+              )},
+            textColor: Colors.white,
+            color: Colors.lightBlue,
+            shape: RoundedRectangleBorder(
+              borderRadius: new BorderRadius.circular(15.0),
+            ),
+            padding: EdgeInsets.symmetric(vertical: 15.0),
+          ),
+          FlatButton(
+            child: Text(notSignUp),
+            onPressed: () => {
+              // TO-DO: 회원가입 BLOC 구현하기
+            },
+          )
+        ],
       ),
     );
   }

--- a/lib/ui/pages/splash_screen.dart
+++ b/lib/ui/pages/splash_screen.dart
@@ -23,6 +23,7 @@ class _SplashScreenState extends State<SplashScreenPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      key: Key('SplashScreenPage'),
       backgroundColor: Colors.white,
       body: Center(
         child: Text(title),

--- a/lib/ui/pages/splash_screen.dart
+++ b/lib/ui/pages/splash_screen.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'package:Eliverd/common/string.dart';
-import './home.dart';
+import './login.dart';
 
 class SplashScreenPage extends StatefulWidget {
   @override
@@ -17,15 +17,15 @@ class _SplashScreenState extends State<SplashScreenPage> {
     Timer(
       Duration(seconds: 3),
         () => Navigator.of(context).pushReplacement(MaterialPageRoute(
-        builder: (BuildContext context) => HomePage())));
+        builder: (BuildContext context) => LoginPage())));
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
-      appBar: AppBar(
-        title: Text(title),
+      body: Center(
+        child: Text(title),
       ),
     );
   }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,16 +1,38 @@
-
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:Eliverd/main.dart';
 
+import 'package:Eliverd/common/string.dart';
+
 void main() {
   testWidgets('Main Test', (WidgetTester tester) async {
+    final splashScreenPageKey = Key('SplashScreenPage');
+    final loginPageKey = Key('LoginPage');
+    final homePageKey = Key('HomePage');
+    final idFieldKey = Key('IdField');
+    final passwordFieldKey = Key('PasswordField');
+    final signInButtonKey = Key('SignInButton');
+    final signUpButtonKey = Key('SignUpButton');
+
     await tester.pumpWidget(EliverdStore());
 
-    expect(find.text('Eliverd'), findsOneWidget);
+    expect(find.byKey(splashScreenPageKey), findsOneWidget);
+
+    expect(find.text(title), findsOneWidget);
 
     await tester.pumpAndSettle(const Duration(seconds: 3));
 
-    expect(find.text('Eliverd'), findsOneWidget);
+    expect(find.byKey(loginPageKey), findsOneWidget);
+
+    expect(find.byKey(idFieldKey), findsOneWidget);
+    expect(find.byKey(passwordFieldKey), findsOneWidget);
+    expect(find.byKey(signInButtonKey), findsOneWidget);
+    expect(find.byKey(signUpButtonKey), findsOneWidget);
+
+    await tester.tap(find.byKey(signInButtonKey));
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+
+    expect(find.byKey(homePageKey), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 1차 스프린트 결과

### ✅ 완료된 것
- 애플리케이션을 실행했을 때 Splash Screen, 로그인, 메인 페이지까지의 Navigation의 틀이 모두 완성되었습니다.(#10, #11)

### ⚠️ 보완할 것
백로그 #8, #9 (재고 열람, 상품 등록, 폐기 기능 추가)의 경우 아직 User와 Product의 모델링이 완전히 되지 않아서 중복 구현을 막는 것이 좋을 것이라 판단하여 다음 스프린트로 미루었습니다.
- Product에 대한 위젯 UI를 구현해야 합니다.
- User와 Product의 모델링을 마쳐서 BLOC 틀을 구현해놓아야 합니다.
- 로그인 페이지의 인증 절차(로그인, 회원가입)을 구현해야 합니다. (#13)

### ❌ 문제가 있는 것
- 없음